### PR TITLE
Update SerialClient.py

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -282,6 +282,9 @@ class RosSerialServer:
 
     def flushInput(self):
         pass
+    
+    def flushOutput(self):
+        pass
 
     def write(self, data):
         if not self.isConnected:


### PR DESCRIPTION
flushInput/Output are maybe depreciated, but adding the flushOutput definition seems to be required. Source here: https://github.com/ros-drivers/rosserial/issues/427